### PR TITLE
Add edit preference

### DIFF
--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PreferencesController < ApplicationController
-  before_action :set_preference, only: %i[show]
+  before_action :set_preference, only: %i[show edit update]
 
   def index
     @preferences = current_user.preferences
@@ -14,6 +14,8 @@ class PreferencesController < ApplicationController
     @preference = Preference.new
   end
 
+  def edit; end
+
   def create
     @preference = current_user.preferences.build(preference_params)
 
@@ -21,6 +23,14 @@ class PreferencesController < ApplicationController
       redirect_to preferences_path, notice: t('views.preferences.create_success')
     else
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def update
+    if @preference.update(preference_params)
+      redirect_to preferences_path, notice: t('views.preferences.update_success')
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -17,6 +17,8 @@
 #  index_preferences_on_user_id  (user_id)
 #
 class Preference < ApplicationRecord
+  Preference::MAX_PREFERENCES = 5
+
   belongs_to :user
 
   validates :name, presence: true

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -17,7 +17,7 @@
 #  index_preferences_on_user_id  (user_id)
 #
 class Preference < ApplicationRecord
-  Preference::MAX_PREFERENCES = 5
+  MAX_PREFERENCES = 5
 
   belongs_to :user
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,7 @@ en:
       show_preference: Show Preference
       title: Preferences
       update_preference: Update Preference
+      update_success: Preference successfully updated
     recipes:
       cancel: Cancel
       close_panel: Close

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
   end
 
   resources :users
-  resources :preferences, only: %i[index new create show]
+  resources :preferences, only: %i[index new create show edit update]
   resources :recipes, only: %i[index]
 
   namespace :api do

--- a/spec/features/preferences/edit_spec.rb
+++ b/spec/features/preferences/edit_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Edit preference' do
+  subject { visit edit_preference_path(preference) }
+
+  let!(:user) { create(:user) }
+  let!(:preference) { create(:preference, user:) }
+
+  before do
+    sign_in user
+    subject
+  end
+
+  describe 'render preference form' do
+    it 'shows the preference name' do
+      within('form') do
+        expect(page).to have_field('preference[name]', with: preference.name)
+      end
+    end
+
+    it 'shows the preference description' do
+      within('form') do
+        expect(page).to have_field('preference[description]', with: preference.description)
+      end
+    end
+
+    it 'shows the preference restriction' do
+      within('form') do
+        expect(page).to have_field('preference[restriction]', checked: preference.restriction)
+      end
+    end
+  end
+
+  describe 'update preference' do
+    context 'with valid data' do
+      let(:new_name) { 'New Preference Name' }
+      let(:new_description) { 'New Preference Description' }
+      let(:restriction) { true }
+
+      before do
+        fill_in 'preference[name]', with: new_name
+        fill_in 'preference[description]', with: new_description
+        check 'preference[restriction]'
+        click_on 'Update Preference'
+      end
+
+      it 'redirects to the preferences index page' do
+        expect(page).to have_current_path(preferences_path)
+      end
+
+      it 'shows a success message' do
+        expect(page).to have_content(I18n.t('views.preferences.update_success'))
+      end
+
+      it 'updates the preference name' do
+        preference.reload
+        expect(preference.name).to eq(new_name)
+      end
+
+      it 'updates the preference description' do
+        preference.reload
+        expect(preference.description).to eq(new_description)
+      end
+
+      it 'updates the preference restriction' do
+        preference.reload
+        expect(preference.restriction).to eq(restriction)
+      end
+    end
+
+    context 'with invalid data' do
+      let(:invalid_name) { '' }
+      let(:invalid_description) { '' }
+
+      before do
+        fill_in 'preference[name]', with: invalid_name
+        fill_in 'preference[description]', with: invalid_description
+        click_on 'Update Preference'
+      end
+
+      it 'renders the form' do
+        within('form') do
+          expect(page).to have_field('preference[name]', with: invalid_name)
+          expect(page).to have_field('preference[description]', with: invalid_description)
+        end
+      end
+
+      it 'renders the error messages' do
+        expect(page).to have_text("Name can't be blank", wait: 5)
+        expect(page).to have_text("Description can't be blank", wait: 5)
+      end
+    end
+  end
+end

--- a/spec/features/preferences/update_spec.rb
+++ b/spec/features/preferences/update_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Edit preference' do
+  subject { visit edit_preference_path(preference) }
+
+  let!(:user) { create(:user) }
+  let!(:preference) { create(:preference, user:) }
+
+  before do
+    sign_in user
+    subject
+  end
+
+  it 'shows the preference name' do
+    within('form') do
+      expect(page).to have_field('preference[name]', with: preference.name)
+    end
+  end
+
+  it 'shows the preference description' do
+    within('form') do
+      expect(page).to have_field('preference[description]', with: preference.description)
+    end
+  end
+
+  it 'shows the preference restriction' do
+    within('form') do
+      expect(page).to have_field('preference[restriction]', checked: preference.restriction)
+    end
+  end
+end

--- a/spec/requests/preferences/preferences_spec.rb
+++ b/spec/requests/preferences/preferences_spec.rb
@@ -21,4 +21,81 @@ RSpec.describe 'preferences' do
       end
     end
   end
+
+  describe 'GET #edit' do
+    subject { get edit_preference_path(preference) }
+
+    let!(:preference) { create(:preference) }
+
+    context 'when logged in' do
+      let!(:user) { create(:user) }
+
+      before { sign_in user }
+
+      it 'returns a success response' do
+        subject
+        expect(response).to have_http_status(:success)
+      end
+
+      it 'includes the preference name' do
+        subject
+        expect(response.body).to include(preference.name)
+      end
+    end
+
+    context 'when no logged in' do
+      it 'is redirected to login' do
+        subject
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
+
+  describe 'PATCH #update' do
+    subject { patch preference_path(preference), params: { preference: attributes } }
+
+    let!(:preference) { create(:preference) }
+    let(:attributes) do
+      {
+        name: 'New Name',
+        description: 'New Description',
+        restriction: true
+      }
+    end
+
+    context 'when logged in' do
+      let!(:user) { create(:user) }
+
+      before { sign_in user }
+
+      context 'with valid data' do
+        it 'is redirected' do
+          subject
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      context 'with invalid data' do
+        let(:attributes) do
+          {
+            name: '',
+            description: '',
+            restriction: nil
+          }
+        end
+
+        it 'return unprocessable entity' do
+          subject
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+      end
+    end
+
+    context 'when no logged in' do
+      it 'is redirected to login' do
+        subject
+        expect(response).to have_http_status(:redirect)
+      end
+    end
+  end
 end

--- a/spec/requests/preferences/preferences_spec.rb
+++ b/spec/requests/preferences/preferences_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe 'preferences' do
   describe 'GET #edit' do
     subject { get edit_preference_path(preference) }
 
-    let!(:preference) { create(:preference) }
+    let!(:user) { create(:user) }
+    let!(:preference) { create(:preference, user:) }
 
     context 'when logged in' do
-      let!(:user) { create(:user) }
-
       before { sign_in user }
 
       it 'returns a success response' do
@@ -54,7 +53,8 @@ RSpec.describe 'preferences' do
   describe 'PATCH #update' do
     subject { patch preference_path(preference), params: { preference: attributes } }
 
-    let!(:preference) { create(:preference) }
+    let!(:user) { create(:user) }
+    let!(:preference) { create(:preference, user:) }
     let(:attributes) do
       {
         name: 'New Name',
@@ -64,8 +64,6 @@ RSpec.describe 'preferences' do
     end
 
     context 'when logged in' do
-      let!(:user) { create(:user) }
-
       before { sign_in user }
 
       context 'with valid data' do


### PR DESCRIPTION
#### Board:
* [Ticket #3](https://www.notion.so/3-Edit-Preference-1120fb200b42816389f0d11f3a0876e5?pvs=4)
---
#### Description:
This PR adds edit and update actions for PreferenceController


https://github.com/user-attachments/assets/d918014e-6a80-4b87-9b86-d1a5099b1fb3


---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:
