### PR TITLE
Add user preferences to recipe

### DIFF
--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -44,8 +44,8 @@ class RecipeGeneratorService
     <<~CONTENT
       Write a recipe following these rules:
       1) The recipe MUST include only the ingredients provided.
-      2) The recipe SHOULD follow the preferences provided.
-      3) DO NOT include any ingredients listed as restrictions.
+      2) Every preference MUST be incorporated into the recipe.
+      3) The recipe SHOULD exclude any ingredients listed as restrictions.
       4) Your response MUST be in JSON format, as this example:
       { "name": "Dish Name",
         "content": "Recipe instructions" }
@@ -63,7 +63,7 @@ class RecipeGeneratorService
   end
 
   def preferences
-    @user.preferences.where.not(restriction: false).map(&:description).join(', ') || ''
+    @user.preferences.where(restriction: false).map(&:description).join(', ') || ''
   end
 
   def openai_client

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -44,7 +44,9 @@ class RecipeGeneratorService
     <<~CONTENT
       Write a recipe following these rules:
       1) The recipe MUST include only the ingredients provided.
-      2) Your response MUST be in JSON format, as this example:
+      2) The recipe SHOULD follow the preferences provided.
+      3) DO NOT include any ingredients listed as restrictions.
+      4) Your response MUST be in JSON format, as this example:
       { "name": "Dish Name",
         "content": "Recipe instructions" }
     CONTENT
@@ -52,8 +54,16 @@ class RecipeGeneratorService
 
   def new_message
     [
-      { role: 'user', content: "Ingredients: #{message}" }
+      { role: 'user', content: "Ingredients: #{message}, Preferences: #{preferences}, Restrictions: #{restrictions}" }
     ]
+  end
+
+  def restrictions
+    @user.preferences.where(restriction: true).map(&:description).join(', ') || ''
+  end
+
+  def preferences
+    @user.preferences.where.not(restriction: false).map(&:description).join(', ') || ''
   end
 
   def openai_client

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -45,7 +45,7 @@ class RecipeGeneratorService
       Write a recipe following these rules:
       1) The recipe MUST include only the ingredients provided.
       2) Every preference MUST be incorporated into the recipe.
-      3) The recipe SHOULD exclude any ingredients listed as restrictions.
+      3) The recipe MUST exclude any ingredients listed as restrictions.
       4) Your response MUST be in JSON format, as this example:
       { "name": "Dish Name",
         "content": "Recipe instructions" }
@@ -58,12 +58,16 @@ class RecipeGeneratorService
     ]
   end
 
+  def user_preferences(restriction)
+    @user_preferences ||= @user.preferences.where(restriction:).map(&:description).join(', ')
+  end
+
   def restrictions
-    @user.preferences.where(restriction: true).map(&:description).join(', ') || ''
+    user_preferences(true)
   end
 
   def preferences
-    @user.preferences.where(restriction: false).map(&:description).join(', ') || ''
+    user_preferences(false)
   end
 
   def openai_client

--- a/spec/features/recipes/create_spec.rb
+++ b/spec/features/recipes/create_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe 'Create recipe' do
                   content: "Write a recipe following these rules:\n" \
                            "1) The recipe MUST include only the ingredients provided.\n" \
                            "2) Every preference MUST be incorporated into the recipe.\n" \
-                           "3) The recipe SHOULD exclude any ingredients listed as restrictions.\n" \
+                           "3) The recipe MUST exclude any ingredients listed as restrictions.\n" \
                            "4) Your response MUST be in JSON format, as this example:\n" \
                            "{ \"name\": \"Dish Name\",\n  \"content\": \"Recipe instructions\" }\n" },
                 { role: 'user',
@@ -67,7 +67,7 @@ RSpec.describe 'Create recipe' do
                       content: "Write a recipe following these rules:\n" \
                                "1) The recipe MUST include only the ingredients provided.\n" \
                                "2) Every preference MUST be incorporated into the recipe.\n" \
-                               "3) The recipe SHOULD exclude any ingredients listed as restrictions.\n" \
+                               "3) The recipe MUST exclude any ingredients listed as restrictions.\n" \
                                "4) Your response MUST be in JSON format, as this example:\n" \
                                "{ \"name\": \"Dish Name\",\n  \"content\": \"Recipe instructions\" }\n"
                     }.to_json

--- a/spec/features/recipes/create_spec.rb
+++ b/spec/features/recipes/create_spec.rb
@@ -43,8 +43,8 @@ RSpec.describe 'Create recipe' do
                 { role: 'system',
                   content: "Write a recipe following these rules:\n" \
                            "1) The recipe MUST include only the ingredients provided.\n" \
-                           "2) The recipe SHOULD follow the preferences provided.\n" \
-                           "3) DO NOT include any ingredients listed as restrictions.\n" \
+                           "2) Every preference MUST be incorporated into the recipe.\n" \
+                           "3) The recipe SHOULD exclude any ingredients listed as restrictions.\n" \
                            "4) Your response MUST be in JSON format, as this example:\n" \
                            "{ \"name\": \"Dish Name\",\n  \"content\": \"Recipe instructions\" }\n" },
                 { role: 'user',
@@ -66,8 +66,8 @@ RSpec.describe 'Create recipe' do
                       name: 'Tomato Bread',
                       content: "Write a recipe following these rules:\n" \
                                "1) The recipe MUST include only the ingredients provided.\n" \
-                               "2) The recipe SHOULD follow the preferenes provided.\n" \
-                               "3) DO NOT include any ingredients listed as restrictions.\n" \
+                               "2) Every preference MUST be incorporated into the recipe.\n" \
+                               "3) The recipe SHOULD exclude any ingredients listed as restrictions.\n" \
                                "4) Your response MUST be in JSON format, as this example:\n" \
                                "{ \"name\": \"Dish Name\",\n  \"content\": \"Recipe instructions\" }\n"
                     }.to_json


### PR DESCRIPTION
#### Board:
* [Ticket #7](https://www.notion.so/Backlog-1120fb200b42804883aefeb9f5f4c92e?p=1120fb200b42810b918af888a707938c&pm=s)
---
#### Description:
This PR include preferences on the recipe service.
---
#### Notes:
On the video, I create a recipe for a user with 2 preferences already created. 1 Preference - Use microwave, 1 Preference as restriction- Do not use Salt.
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:

https://github.com/user-attachments/assets/c9546aa2-ab19-4715-ba8b-40e5561d1a3e

