### PR TITLE
Add max preferences validation

### DIFF
--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -24,10 +24,10 @@ class Preference < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
   validates :restriction, inclusion: { in: [true, false] }
-  validate :validate_preferences_number, on: :create
+  validate :preferences_number, on: :create
 
-  def validate_preferences_number
-    return unless user.preferences.size >= MAX_PREFERENCES
+  def preferences_number
+    return unless user && user.preferences.size >= MAX_PREFERENCES
 
     errors.add(:base, I18n.t('views.preferences.limit_reached_message', max: MAX_PREFERENCES))
   end

--- a/app/models/preference.rb
+++ b/app/models/preference.rb
@@ -24,4 +24,11 @@ class Preference < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
   validates :restriction, inclusion: { in: [true, false] }
+  validate :validate_preferences_number, on: :create
+
+  def validate_preferences_number
+    return unless user.preferences.size >= MAX_PREFERENCES
+
+    errors.add(:base, I18n.t('views.preferences.limit_reached_message', max: MAX_PREFERENCES))
+  end
 end

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -54,7 +54,7 @@ class RecipeGeneratorService
 
   def new_message
     [
-      { role: 'user', content: "Ingredients: #{message}, Preferences: #{preferences}, Restrictions: #{restrictions}, Preferences: #{preferences}, Restrictions: #{restrictions}" }
+      { role: 'user', content: "Ingredients: #{message}, Preferences: #{preferences}, Restrictions: #{restrictions}" }
     ]
   end
 

--- a/app/services/recipe_generator_service.rb
+++ b/app/services/recipe_generator_service.rb
@@ -54,7 +54,7 @@ class RecipeGeneratorService
 
   def new_message
     [
-      { role: 'user', content: "Ingredients: #{message}, Preferences: #{preferences}, Restrictions: #{restrictions}" }
+      { role: 'user', content: "Ingredients: #{message}, Preferences: #{preferences}, Restrictions: #{restrictions}, Preferences: #{preferences}, Restrictions: #{restrictions}" }
     ]
   end
 

--- a/spec/features/preferences/create_spec.rb
+++ b/spec/features/preferences/create_spec.rb
@@ -31,9 +31,10 @@ RSpec.describe 'Create preference' do
   context 'when the user has reached the maximum number of preferences' do
     let!(:user_with_max_preferences) { create(:user) }
     let!(:preference) { build(:preference) }
+    let!(:max_preferences) { Preference::MAX_PREFERENCES }
 
     before do
-      create_list(:preference, Preference::MAX_PREFERENCES, user: user_with_max_preferences)
+      create_list(:preference, max_preferences, user: user_with_max_preferences)
       sign_in user_with_max_preferences
       visit new_preference_path
       fill_in 'preference[name]', with: preference[:name]
@@ -42,11 +43,11 @@ RSpec.describe 'Create preference' do
     end
 
     it 'render the error message' do
-      expect(page).to have_content(I18n.t('views.preferences.limit_reached_message', max: Preference::MAX_PREFERENCES))
+      expect(page).to have_content(I18n.t('views.preferences.limit_reached_message', max: max_preferences))
     end
 
     it 'do not creates the preference' do
-      expect(Preference.where(user: user_with_max_preferences).count).to eq(Preference::MAX_PREFERENCES)
+      expect(Preference.where(user: user_with_max_preferences).count).to eq(max_preferences)
     end
   end
 end

--- a/spec/features/preferences/create_spec.rb
+++ b/spec/features/preferences/create_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Create preference' do
+  let!(:user) { create(:user) }
+  let!(:preference) { build(:preference, user:) }
+
+  before do
+    sign_in user
+    visit new_preference_path
+    fill_in 'preference[name]', with: preference[:name]
+    fill_in 'preference[description]', with: preference[:description]
+    click_on 'Create Preference'
+  end
+
+  context 'with valid data' do
+    it 'redirects to the preferences index page' do
+      expect(page).to have_current_path(preferences_path)
+    end
+
+    it 'shows a success message' do
+      expect(page).to have_content(I18n.t('views.preferences.create_success'))
+    end
+
+    it 'creates the preference' do
+      expect(Preference.count).to eq(1)
+    end
+  end
+
+  context 'when the user has reached the maximum number of preferences' do
+    let!(:user_with_max_preferences) { create(:user) }
+    let!(:preference) { build(:preference) }
+
+    before do
+      create_list(:preference, Preference::MAX_PREFERENCES, user: user_with_max_preferences)
+      sign_in user_with_max_preferences
+      visit new_preference_path
+      fill_in 'preference[name]', with: preference[:name]
+      fill_in 'preference[description]', with: preference[:description]
+      click_on 'Create Preference'
+    end
+
+    it 'render the error message' do
+      expect(page).to have_content(I18n.t('views.preferences.limit_reached_message', max: Preference::MAX_PREFERENCES))
+    end
+
+    it 'do not creates the preference' do
+      expect(Preference.where(user: user_with_max_preferences).count).to eq(Preference::MAX_PREFERENCES)
+    end
+  end
+end


### PR DESCRIPTION
#### Board:
* [Ticket #10](https://www.notion.so/Backlog-1120fb200b42804883aefeb9f5f4c92e?p=1120fb200b4281189f09ca87b2c34963&pm=s)
---
#### Description:
This PR adds a validation to allow user to have until 5 preferences.
---
#### Notes:
*
---
#### Tasks:
- [x] Add each element in this format
---
#### Risk:
*
---
#### Preview:

https://github.com/user-attachments/assets/31441257-a8ce-4b26-bada-529a39e26462

